### PR TITLE
244 case insensitive postcode search

### DIFF
--- a/HousingManagementSystemApi/Repositories/UniversalHousingAddressesRepository.cs
+++ b/HousingManagementSystemApi/Repositories/UniversalHousingAddressesRepository.cs
@@ -43,7 +43,7 @@ namespace HousingManagementSystemApi.Repositories
                     ON r.prop_type = ptype.lu_ref
                 WHERE level_code in ('2')
                 AND eot = '1900-01-01 00:00:00'
-                AND (post_code like '%{postcode}%' OR REPLACE(post_code, ' ','') like '%{postcode}%')
+                AND (UPPER(REPLACE(post_code, ' ','')) like UPPER(REPLACE('%{postcode}%', ' ','')))
             ";
 
             var result = Enumerable.Empty<PropertyAddress>();


### PR DESCRIPTION
Once [PR 4](https://github.com/City-of-Lincoln-Council/HousingManagementSystemApi/pull/4) is merged, the only change in this PR to the SQL used.

Use this [link](https://github.com/City-of-Lincoln-Council/HousingManagementSystemApi/compare/135-universal-housing-integration...244-case-insensitive-postcode-search?expand=1) to see the difference - may need to scroll to the bottom to see the code diff.